### PR TITLE
#162149933 - Allow users to create, read, edit, and delete diary entry

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ deploy:
   skip-cleanup: true
   github-token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
   keep-history: true
-  local-dir: client
+  local-dir: client/dist
   on:
     branch: develop
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -2,6 +2,7 @@ import React from 'react';
 import Navbar from './component/Navbar';
 import Footer from './component/Footer';
 import Body from './component/Body';
+import Modal from './component/modal/index';
 import Toast from './component/notification/Toast';
 
 const App = () => (
@@ -9,6 +10,7 @@ const App = () => (
     <Navbar/>
     <Body/>
     <Footer/>
+    <Modal/>
     <Toast/>
   </React.Fragment>
 );

--- a/client/src/PrivateRoute.jsx
+++ b/client/src/PrivateRoute.jsx
@@ -1,0 +1,46 @@
+import { Redirect, Route } from 'react-router-dom';
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import saveReferrer from './actions/redirect';
+
+class PrivateRoute extends Component {
+  render() {
+    const {
+      component: Components, isAuthenticated, saveReferrer: save, ...rest
+    } = this.props;
+    return (
+      <Route
+        {...rest}
+        render={(props) => {
+          if (isAuthenticated) {
+            return (
+              <Components {...props} />
+            );
+          }
+          save(props.location.pathname);
+          return (
+            <Redirect
+              to={{
+                pathname: '/signin',
+                state: { from: props.location },
+              }}
+            />
+          );
+        }
+        }
+      />
+    );
+  }
+}
+
+PrivateRoute.propTypes = {
+  component: PropTypes.any,
+  isAuthenticated: PropTypes.bool,
+  saveReferrer: PropTypes.func,
+};
+const mapStateToProps = state => ({
+  isAuthenticated: state.authenticate.authenticated,
+});
+
+export default connect(mapStateToProps, { saveReferrer })(PrivateRoute);

--- a/client/src/actions/constants.js
+++ b/client/src/actions/constants.js
@@ -1,14 +1,7 @@
-export const ADD_ENTRY = 'ADD ENTRY';
-export const SET_ENTRY = 'SET ENTRY';
-export const ENTRY_LOADING = 'ENTRY_LOADING';
-export const REMOVE_ENTRY = 'REMOVE ENTRY';
-export const SET_ENTRIES = 'SET ENTRIES';
-export const UPDATE_ENTRY = 'UPDATE ENTRIES';
 export const UPDATING_PROFILE = 'UPDATING PROFILE';
 export const UPDATING_PASSWORD = 'UPDATING PASSWORD';
 export const UPDATING_SETTINGS = 'UPDATING SETTINGS';
 export const REDIRECT_TO_REFERRER = 'REDIRECT TO REFERRER';
-export const SET_QUERY = 'SET QUERY';
 export const SET_PROFILE = 'SET PROFILE';
 export const SET_REMINDER = 'SET REMINDER';
 export const SET_SUMMARY = 'SET SUMMARY';

--- a/client/src/actions/entries.js
+++ b/client/src/actions/entries.js
@@ -1,0 +1,150 @@
+import { apiRequest } from '../services/index';
+import { DEFAULT_SIZE } from './constants';
+import { dismissModal } from './modal';
+import { showToast } from './notification';
+
+export const SET_QUERY = 'SET QUERY';
+
+export const ADD_ENTRY = 'ADD ENTRY';
+export const ENTRY_LOADING = 'ENTRY_LOADING';
+export const REMOVE_ENTRY = 'REMOVE ENTRY';
+export const SET_ENTRIES = 'SET ENTRIES';
+export const UPDATE_ENTRY = 'UPDATE ENTRIES';
+
+export const requesting = loading => ({
+  type: ENTRY_LOADING,
+  loading
+});
+
+/**
+ *
+ * @returns {{type: string, entryList: Array<object>}}
+ * @param entryList
+ */
+export const setEntries = entryList => ({
+  type: SET_ENTRIES,
+  entryList,
+});
+
+/**
+ *
+ * @returns {{type: string, entry: object}}
+ * @param entry
+ */
+export const addEntry = entry => ({
+  type: ADD_ENTRY,
+  entry,
+});
+
+/**
+ *
+ * @returns {{type: string, entry: object}}
+ * @param entry
+ */
+export const updateEntries = entry => ({
+  type: UPDATE_ENTRY,
+  entry,
+});
+
+/**
+ *
+ * @param {number} page
+ * @param {number} size
+ * @param {number} total
+ * @return {
+ *          {
+ *            type: string,
+ *            query: {
+ *              page: number, size: number, total: number
+ *            }
+ *          }
+ *         }
+ */
+export const setQuery = ({ page, size, total }) => ({
+  type: SET_QUERY,
+  query: {
+    page: Number(page),
+    size: Number(size),
+    total: Number(total)
+  },
+});
+
+/**
+ *
+ * @returns {{type: string, entry: object}}
+ * @param id
+ */
+export const removeEntry = id => ({
+  type: REMOVE_ENTRY,
+  id,
+});
+
+export const getEntries = query => async (dispatch) => {
+  try {
+    const result = await apiRequest.getEntries(query);
+    const { size } = query;
+    const { data } = result;
+    const { entries, page, totalEntries: total } = data;
+    dispatch(setEntries(entries));
+    dispatch(setQuery({
+      page,
+      total,
+      size: size || DEFAULT_SIZE
+    }));
+  } catch (e) {
+    dispatch(setEntries([]));
+    dispatch(showToast({
+      type: 'error',
+      text: e.message,
+      timeout: 5000
+    }));
+  }
+};
+
+export const updateEntry = (id, data) => async (dispatch) => {
+  try {
+    dispatch(requesting(true));
+    const result = await apiRequest.updateEntry(id, data);
+    dispatch(requesting(false));
+    dispatch(updateEntries(result.entry));
+    dispatch(dismissModal());
+  } catch (error) {
+    dispatch(requesting(false));
+    dispatch(showToast({
+      type: 'error',
+      text: ''
+    }));
+  }
+};
+
+export const createEntry = details => async (dispatch) => {
+  try {
+    dispatch(requesting(true));
+    const result = await apiRequest.createEntry(details);
+    dispatch(requesting(false));
+    dispatch(addEntry(result.entry));
+    dispatch(dismissModal());
+  } catch (error) {
+    dispatch(requesting(false));
+    dispatch(showToast({
+      type: 'error',
+      text: ''
+    }));
+  }
+};
+
+export const deleteEntry = id => async (dispatch) => {
+  try {
+    dispatch(requesting(true));
+    await apiRequest.deleteEntry(id);
+    dispatch(requesting(false));
+    dispatch(dismissModal());
+    dispatch(removeEntry(id));
+  } catch (error) {
+    dispatch(requesting(false));
+    dispatch(showToast({
+      type: 'error',
+      text: error.message
+    }));
+  }
+};

--- a/client/src/actions/modal.js
+++ b/client/src/actions/modal.js
@@ -1,0 +1,7 @@
+export const MODAL_ACTION = 'MODAL_ACTION';
+const type = MODAL_ACTION;
+const modal = (show, content = {}) => ({ type, show, content });
+
+export const openModal = content => dispatch => dispatch(modal(true, content));
+
+export const dismissModal = () => dispatch => dispatch(modal(false));

--- a/client/src/component/Body.jsx
+++ b/client/src/component/Body.jsx
@@ -4,6 +4,8 @@ import NotFoundPage from './NotFoundPage';
 import HomePage from './HomePage';
 import SignupPage from './SignupPage';
 import SigninPage from './SigninPage';
+import EntryListPage from './entries/EntryListPage';
+import PrivateRoute from '../PrivateRoute';
 
 const Body = () => (
   <main>
@@ -11,6 +13,7 @@ const Body = () => (
       <Route exact path="/" component={HomePage}/>
       <Route exact path="/signin" component={SigninPage} />
       <Route exact path="/signup" component={SignupPage}/>
+      <PrivateRoute exact path="/dashboard" component={EntryListPage} />
       <Route component={NotFoundPage}/>
     </Switch>
   </main>

--- a/client/src/component/Navbar.jsx
+++ b/client/src/component/Navbar.jsx
@@ -1,7 +1,8 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Link, withRouter } from 'react-router-dom';
 import { connect } from 'react-redux';
+import { Link, withRouter } from 'react-router-dom';
+import { logoutUser } from '../actions/authUser';
 
 export class Navbar extends React.Component {
   constructor(props) {
@@ -71,7 +72,7 @@ export class Navbar extends React.Component {
                     <Link to="/profile">Profile</Link>
                   </li>
                   <li>
-                    <a className="logout-js">Logout</a>
+                    <a onClick={this.props.logoutUser} className="logout-js">Logout</a>
                   </li>
                 </ul>
               )}
@@ -109,7 +110,7 @@ export class Navbar extends React.Component {
                   <Link to="/profile">Profile</Link>
                 </li>
                 <li>
-                  <a className="logout-js">Logout</a>
+                  <a onClick={this.props.logoutUser} className="logout-js">Logout</a>
                 </li>
               </ul>
             )}
@@ -130,21 +131,13 @@ export class Navbar extends React.Component {
   }
 }
 
-Navbar.propTypes = {
-  authenticated: PropTypes.bool,
-  hideNavBar: PropTypes.bool,
-};
-Navbar.defaultProps = {
-  authenticated: false,
-  hideNavBar: false,
-};
-
-
 const mapStateToProps = state => ({
+  authenticated: state.authenticate.authenticated,
   hideNavBar: state.toolbar.hideNavBar,
 });
 
 Navbar.propTypes = {
+  logoutUser: PropTypes.func.isRequired,
   authenticated: PropTypes.bool,
   hideNavBar: PropTypes.bool,
 };
@@ -153,4 +146,4 @@ Navbar.defaultProps = {
   hideNavBar: false,
 };
 
-export default withRouter(connect(mapStateToProps, null)(Navbar));
+export default withRouter(connect(mapStateToProps, { logoutUser })(Navbar));

--- a/client/src/component/entries/BottomPagination.jsx
+++ b/client/src/component/entries/BottomPagination.jsx
@@ -1,0 +1,62 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { DEFAULT_SIZE } from '../../actions/constants';
+import { queryInfoPropType } from '../propsValidator';
+
+export class BottomPagination extends Component {
+  constructor(props) {
+    super(props);
+    this.view = React.createRef();
+  }
+
+  handlePageChange = (e) => {
+    const { target } = e;
+    let { page } = this.props.queryInfo;
+    const { total, size } = this.props.queryInfo;
+    const totalPages = Math.max(Math.ceil(total / size), 1);
+    const direction = target.getAttribute('data-direction');
+    if (direction === 'next') {
+      page += 1;
+    } else {
+      page -= 1;
+    }
+    if (page > 0 && page <= totalPages) {
+      this.props.onPageChange({
+        page,
+        size: DEFAULT_SIZE
+      });
+    }
+  };
+
+  renderBottom = () => {
+    const { total, page, size } = this.props.queryInfo;
+    const totalPages = Math.max(Math.ceil(total / size), 1);
+    return `Page ${page} of ${totalPages}`;
+  };
+
+  render() {
+    return (
+      <div className="center">
+        <div className="pagination">
+          <a className='prev-js' onClick={this.handlePageChange} data-direction="prev">❮</a>
+          <a data-model="page" className="disable">{this.renderBottom()}</a>
+          <a className='next-js' onClick={this.handlePageChange} data-direction="next">❯</a>
+        </div>
+      </div>
+    );
+  }
+}
+
+BottomPagination.propTypes = {
+  onPageChange: PropTypes.func.isRequired,
+  queryInfo: queryInfoPropType.isRequired
+};
+
+BottomPagination.defaultProps = {
+  queryInfo: {
+    page: 1,
+    size: DEFAULT_SIZE,
+    total: 0
+  }
+};
+export default BottomPagination;

--- a/client/src/component/entries/CreateEntry.jsx
+++ b/client/src/component/entries/CreateEntry.jsx
@@ -1,0 +1,149 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import ButtonLoader from '../ButtonLoader';
+import { entryPropType } from '../propsValidator';
+
+export default class CreateEntry extends Component {
+  constructor(props) {
+    super(props);
+    const { entry } = this.props;
+    let content = '',
+      title = '',
+      lastModified = '';
+    if (entry) {
+      ({
+        content,
+        title,
+        lastModified
+      } = entry);
+    }
+    this.state = {
+      content,
+      title,
+      lastModified
+    };
+  }
+
+  updateState = (e) => {
+    const data = {};
+    data[e.target.name] = e.target.value;
+    this.setState({ ...data });
+  };
+
+  validateTitle = (title) => {
+    const titlePattern = /^[a-zA-Z0-9\-\s&]{8,80}$/;
+
+    if (title) {
+      title = title.trim();
+    }
+
+    if (title && title.match(titlePattern)) return null;
+    let message;
+    if (title.length > 80) {
+      message = 'Title must not exceed 80 characters';
+    } else if (title.length < 8) {
+      message = 'Title must be at least 8 characters';
+    } else {
+      message = 'Title can only contain number, alphabets, space or dash [ - ]';
+    }
+    return message;
+  };
+
+  validateContent = (content) => {
+    if (content) {
+      content = content.trim();
+    }
+
+    let message;
+    if (content.length < 8) {
+      message = 'Content must be at least 8 characters';
+    }
+    return message;
+  };
+
+  onSave = () => {
+    const { content, lastModified, title } = this.state;
+    const error = this.validateTitle(title) || this.validateContent(content);
+    if (error) {
+      this.props.showToast({
+        type: 'error',
+        title: 'Validation Error',
+        text: error,
+        timeout: 8000
+      });
+      return;
+    }
+    this.props.saveEntry({
+      content,
+      lastModified,
+      title
+    });
+  };
+
+  dismiss = () => {
+    this.props.dismissModal();
+  };
+
+  render() {
+    return (
+      <div className="flexbox-parent scrollable">
+        <div id="alert" className="alert error">
+          <p className="alert-msg"/>
+          <span className="close-btn">&times;</span>
+        </div>
+        <div className="modal-header">
+          <div id="modal-header-title">
+            <p data-model="lastModified"/>
+            <input
+              onChange={this.updateState}
+              value={this.state.title}
+              name='title'
+              data-model="title"
+              placeholder="Title"
+              className="form-input modal-header-input"
+            />
+          </div>
+          <span onClick={this.dismiss}
+                data-dismiss="modal"
+                className="action-btn close"
+                role="button"
+                tabIndex="0"
+                aria-label="Close"
+          />
+        </div>
+        <div className="grow-body modal-body">
+          <div className="create-entry">
+            <textarea
+              name='content'
+              onChange={this.updateState}
+              value={this.state.content}
+              placeholder="Dear Diary, " id="entry"/>
+          </div>
+        </div>
+        <div className="modal-footer">
+          <button onClick={this.onSave} data-action="save" type="button" className="btn-save">
+            {
+              this.props.loading
+              && <ButtonLoader/>
+            } {
+            !this.props.loading
+            && <span>Save</span>
+          }
+          </button>
+          <button onClick={this.dismiss} data-dismiss="cancel" type="button"
+                  className="btn-cancel">Cancel
+          </button>
+        </div>
+      </div>
+    );
+  }
+}
+
+CreateEntry.propTypes = {
+  saveEntry: PropTypes.func,
+  loading: PropTypes.bool,
+  dismissModal: PropTypes.func,
+  showToast: PropTypes.func,
+  mode: PropTypes.oneOf(['edit', 'create']),
+  entry: entryPropType
+};

--- a/client/src/component/entries/DeleteEntryDialog.jsx
+++ b/client/src/component/entries/DeleteEntryDialog.jsx
@@ -1,0 +1,40 @@
+import React, { Component, Fragment } from 'react';
+import PropTypes from 'prop-types';
+
+export default class DeleteEntryDialog extends Component {
+  dismiss = () => {
+    this.props.dismissModal();
+  };
+
+  okClicked = () => {
+    this.props.deleteEntry();
+  };
+
+  render() {
+    return (
+      <Fragment>
+        <div className="modal-header">
+            <span className="modal-header-title" role="heading">
+                Confirm Delete
+            </span>
+          <span onClick={this.dismiss} data-dismiss="modal" className="action-btn close" role="button" tabIndex="0"
+                aria-label="Close"/>
+        </div>
+        <div data-model="message" className="modal-body">This action delete entry from database.
+          Are you sure you want to continue?
+        </div>
+        <div className="modal-footer">
+          <button onClick={this.okClicked} data-action="ok" name="ok" className="btn-ok">OK</button>
+          <button onClick={this.dismiss} data-dismiss="cancel" name="cancel">Cancel</button>
+        </div>
+      </Fragment>
+    );
+  }
+}
+
+DeleteEntryDialog.propTypes = {
+  loading: PropTypes.bool,
+  dismissModal: PropTypes.func,
+  deleteEntry: PropTypes.func,
+  showToast: PropTypes.func,
+};

--- a/client/src/component/entries/EmptyList.jsx
+++ b/client/src/component/entries/EmptyList.jsx
@@ -1,0 +1,7 @@
+import React from 'react';
+
+export default function EmptyList() {
+  return (
+    <div className="empty-list"><span>No Entries</span></div>
+  );
+}

--- a/client/src/component/entries/EntryListHeader.jsx
+++ b/client/src/component/entries/EntryListHeader.jsx
@@ -1,0 +1,42 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import TopPagination from './TopPagination';
+import { DEFAULT_SIZE } from '../../actions/constants';
+import { queryInfoPropType } from '../propsValidator';
+
+export default class EntryListHeader extends Component {
+  createEntry = () => {
+    this.props.onCreateEntryClicked();
+  };
+
+  render() {
+    return (
+      <div>
+        <div className="header">
+          <span className="title">Your Diary Entries</span>
+          <div className="add-entry">
+            <a onClick={this.createEntry} id="addEntry" title="Add Entry" className="btn create add-btn-js" role="button">
+              Add
+              Diary Entry
+            </a>
+          </div>
+        </div>
+        <TopPagination {...this.props} id="paginationTop"/>
+      </div>
+    );
+  }
+}
+
+EntryListHeader.propTypes = {
+  onCreateEntryClicked: PropTypes.func.isRequired,
+  onPageChange: PropTypes.func.isRequired,
+  queryInfo: queryInfoPropType.isRequired
+};
+
+EntryListHeader.defaultProps = {
+  queryInfo: {
+    page: 1,
+    size: DEFAULT_SIZE,
+    total: 0
+  }
+};

--- a/client/src/component/entries/EntryListItem.jsx
+++ b/client/src/component/entries/EntryListItem.jsx
@@ -1,0 +1,103 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { entryPropType } from '../propsValidator';
+
+export default class EntryListItem extends Component {
+  showDropDownMenu = (e) => {
+    const { nextElementSibling } = e.target;
+    if (nextElementSibling.classList.contains('open')) {
+      nextElementSibling.classList.remove('open');
+    } else {
+      this.dismissDropDownMenu();
+      nextElementSibling.classList.add('open');
+    }
+    window.addEventListener('click', this.handlerWindowClicked);
+  };
+
+  handlerWindowClicked = (event) => {
+    if (!event.target.matches('.dropdown-toggle-icon')) {
+      this.dismissDropDownMenu();
+      window.removeEventListener('click', this.handlerWindowClicked);
+    }
+  };
+
+  /**
+   * @static
+   * @private
+   */
+  dismissDropDownMenu = () => {
+    const dropdownMenus = document.getElementsByClassName('dropdown-menu');
+    for (let i = 0; i < dropdownMenus.length; i += 1) {
+      const openDropdown = dropdownMenus[i];
+      if (openDropdown.classList.contains('open')) {
+        openDropdown.classList.remove('open');
+      }
+    }
+  };
+
+  handleViewClick = (e) => {
+    const targetElement = e.target;
+    if (targetElement.classList.contains('dropdown-toggle')) {
+      return null;
+    }
+    const attrData = targetElement.getAttribute('data-action');
+    if (attrData) {
+      return null;
+    }
+    this.props.onDropdownItemClicked('view');
+  };
+
+  onDropdownItemClicked = (e) => {
+    const action = e.target.getAttribute('data-action');
+    this.props.onDropdownItemClicked(action);
+    this.dismissDropDownMenu();
+  };
+
+  render() {
+    return (
+      <div
+        onClick={this.handleViewClick}
+        id={`entryListItem${this.props.entry.id}`}
+        className="entry">
+        <p className="title" data-model="title">
+          {this.props.entry.title}
+        </p>
+        <div className="content line-clamp">
+          <p className="block-with-text" data-model="content">
+            {this.props.entry.content}
+          </p>
+        </div>
+        <div className="footer">
+          <div>
+            <span>Last Modified:</span>
+            &nbsp;
+            <span data-model="lastModified">
+              {this.props.entry.lastModified}
+            </span>
+          </div>
+          <div className="dropdown">
+            <span onClick={this.showDropDownMenu}
+                  data-index=""
+                  data-action="dropdown-toggle"
+                  className="dropdown-toggle-icon"
+            />
+            <ul className="dropdown-menu">
+              {
+                ['View', 'Edit', 'Delete'].map(item => (
+                  <li key={item}>
+                    <a onClick={this.onDropdownItemClicked} data-action={item}>{item}</a>
+                  </li>
+                ))
+              }
+            </ul>
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+EntryListItem.propTypes = {
+  entry: entryPropType.isRequired,
+  onDropdownItemClicked: PropTypes.func.isRequired,
+};

--- a/client/src/component/entries/EntryListPage.jsx
+++ b/client/src/component/entries/EntryListPage.jsx
@@ -1,0 +1,177 @@
+import React from 'react';
+import { Redirect, withRouter } from 'react-router-dom';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+import BottomPagination from './BottomPagination';
+import FloatingButton from './FloatingButton';
+import EntryListItem from './EntryListItem';
+import {
+  createEntry, deleteEntry, getEntries, updateEntry
+} from '../../actions/entries';
+import { dismissModal, openModal } from '../../actions/modal';
+import { DEFAULT_SIZE } from '../../actions/constants';
+import EntryListHeader from './EntryListHeader';
+import CreateEntry from './CreateEntry';
+import ViewEntry from './ViewEntry';
+import { showToast } from '../../actions/notification';
+import DeleteEntryDialog from './DeleteEntryDialog';
+import EmptyList from './EmptyList';
+import { entryPropType, queryInfoPropType } from '../propsValidator';
+
+export class EntryListPage extends React.Component {
+  componentDidMount() {
+    this.loadEntries();
+  }
+
+  loadEntries = () => {
+    this.props.getEntries(this.props.queryInfo);
+  };
+
+  openCreateEntryModal = () => {
+    this.openModal('create');
+  };
+
+  openModal = (action, entry) => {
+    let content;
+    const defaultProps = {
+      dismissModal: this.props.dismissModal,
+      showToast: this.props.showToast,
+      entry,
+      mode: action.toLowerCase(),
+    };
+    switch (action.toLowerCase()) {
+      case 'create':
+      case 'edit':
+        content = this.getCreateOrEditContent(defaultProps, entry);
+        break;
+      case 'view':
+        content = this.getViewContent(defaultProps, content);
+        break;
+      case 'delete':
+        content = this.getDeleteContent(defaultProps, entry);
+        break;
+      default:
+        return null;
+    }
+    return this.props.openModal(content);
+  };
+
+  getDeleteContent = (defaultProps, entry) => {
+    const props = {
+      ...defaultProps,
+      deleteEntry: () => {
+        this.props.deleteEntry(entry.id);
+      }
+    };
+    return {
+      component: DeleteEntryDialog,
+      props
+    };
+  };
+
+  getViewContent = (defaultProps) => {
+    const props = {
+      ...defaultProps,
+    };
+    return {
+      component: ViewEntry,
+      props
+    };
+  };
+
+  getCreateOrEditContent = (defaultProps, entry) => {
+    const props = {
+      ...defaultProps,
+      saveEntry: this.props.createEntry,
+    };
+    if (entry) {
+      props.saveEntry = (data) => {
+        this.props.updateEntry(entry.id, data);
+      };
+    }
+    return {
+      component: CreateEntry,
+      props
+    };
+  };
+
+  onPageChange = ({ page, size }) => {
+    this.props.getEntries({
+      page,
+      size
+    });
+  };
+
+  render() {
+    if (!this.props.authenticated) return <Redirect to="/"/>;
+    const { queryInfo, entryList } = this.props;
+    return (
+      <div className="main">
+        <div id="entries" className="entries-container">
+          <EntryListHeader
+            queryInfo={queryInfo}
+            onPageChange={this.onPageChange}
+            onCreateEntryClicked={this.openCreateEntryModal}/>
+          <div className="entry-list">
+            {
+              entryList.length > 0
+              && entryList.map(entry => <EntryListItem
+                onDropdownItemClicked={(action) => {
+                  this.openModal(action, entry);
+                }}
+                key={entry.id} entry={entry}/>)
+            }
+            {
+              entryList.length === 0
+              && <EmptyList/>
+            }
+          </div>
+
+          <BottomPagination
+            queryInfo={queryInfo}
+            onPageChange={this.onPageChange}
+            id="paginationBottom"/>
+
+          <FloatingButton onClicked={this.openCreateEntryModal}/>
+        </div>
+      </div>
+    );
+  }
+}
+
+const mapStateToProps = state => ({
+  authenticated: state.authenticate.authenticated,
+  entryList: state.entries.entryList,
+  queryInfo: state.entries.queryInfo,
+});
+
+EntryListPage.propTypes = {
+  getEntries: PropTypes.func.isRequired,
+  updateEntry: PropTypes.func,
+  createEntry: PropTypes.func,
+  openModal: PropTypes.func,
+  dismissModal: PropTypes.func,
+  deleteEntry: PropTypes.func,
+  showToast: PropTypes.func,
+  authenticated: PropTypes.bool,
+  entryList: PropTypes.arrayOf(entryPropType).isRequired,
+  queryInfo: queryInfoPropType,
+};
+
+EntryListPage.defaultProps = {
+  authenticated: false,
+  queryInfo: {
+    page: 1,
+    size: DEFAULT_SIZE,
+    total: 0
+  }
+};
+export default withRouter(connect(mapStateToProps, {
+  getEntries,
+  updateEntry,
+  createEntry,
+  deleteEntry,
+  openModal,
+  dismissModal,
+  showToast,
+})(EntryListPage));

--- a/client/src/component/entries/FloatingButton.jsx
+++ b/client/src/component/entries/FloatingButton.jsx
@@ -1,0 +1,55 @@
+import React, { Component } from 'react';
+import * as PropTypes from 'prop-types';
+
+export default class FloatingButton extends Component {
+  constructor(props) {
+    super(props);
+    this.root = React.createRef();
+  }
+
+  handleScrollEvent = () => {
+    if (!this.floatBtn) return;
+    if (this.scrollTimer) {
+      clearTimeout(this.scrollTimer);
+    }
+    this.scrollTimer = setTimeout(() => {
+      this.floatBtn.style.transform = 'scale(1)';
+    }, 250);
+
+    this.floatBtn.style.transform = 'scale(0)';
+    const screenHeight = window.innerHeight;
+    const scrollPos = window.scrollY + screenHeight;
+    const bodyHeight = document.body.offsetHeight;
+    if (scrollPos > bodyHeight - 43) {
+      this.floatBtn.style.bottom = `${scrollPos - bodyHeight + 43}px`;
+    } else {
+      this.floatBtn.style.bottom = '15px';
+    }
+  };
+
+  componentDidMount() {
+    this.floatBtn = this.root.current.querySelector('#floatBtn .floating-button ');
+    this.floatBtn.style.transform = 'scale(1)';
+    this.floatBtn.style.bottom = '15px';
+
+    this.scrollTimer = null;
+    document.addEventListener('scroll', this.handleScrollEvent);
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('scroll', this.handleScrollEvent);
+  }
+
+  render() {
+    const { onClicked } = this.props;
+    return (
+      <a ref={this.root} id="floatBtn" title="Add Entry" role="button">
+        <div className="floating-button show-on-mobile">
+          <span onClick={onClicked} title="Add Entry" role="button" className="plus">+</span>
+        </div>
+      </a>
+    );
+  }
+}
+
+FloatingButton.propTypes = { onClicked: PropTypes.any };

--- a/client/src/component/entries/TopPagination.jsx
+++ b/client/src/component/entries/TopPagination.jsx
@@ -1,0 +1,77 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { DEFAULT_SIZE } from '../../actions/constants';
+import { queryInfoPropType } from '../propsValidator';
+
+export class TopPagination extends React.Component {
+  handlePageChange = (e) => {
+    const { target } = e;
+    const { queryInfo } = this.props;
+    let { page } = queryInfo;
+    const { total, size } = queryInfo;
+    const totalPages = Math.max(Math.ceil(total / size), 1);
+    const direction = target.getAttribute('data-direction');
+    if (direction === 'next') {
+      page += 1;
+    } else {
+      page -= 1;
+    }
+    if (page > 0 && page <= totalPages) {
+      this.props.onPageChange({
+        page,
+        size: DEFAULT_SIZE
+      });
+    }
+  };
+
+  renderTop = () => {
+    const { total, page, size } = this.props.queryInfo;
+    const start = ((page - 1) * size) + 1;
+    let end = page * size;
+    end = (end > total) ? total : end;
+    const visibleEntries = `${start} - ${end}`;
+    return {
+      totalEntries: total,
+      visibleEntries,
+      page
+    };
+  };
+
+  render() {
+    const { totalEntries, visibleEntries, page, } = this.renderTop();
+    return (
+      <div className="pagination-container">
+        <div data-page-index={page}>
+          <span data-model="visibleEntries">
+            {visibleEntries}
+          </span>
+          &nbsp;
+          <span>of</span>
+          {' '}
+          &nbsp;
+          <span data-model="totalEntries">
+            {totalEntries}
+          </span>
+        </div>
+        <div className="pagination">
+          <a className='prev-js' onClick={this.handlePageChange} data-direction="prev">❮</a>
+          <a className='next-js' onClick={this.handlePageChange} data-direction="next">❯</a>
+        </div>
+      </div>
+    );
+  }
+}
+
+TopPagination.propTypes = {
+  onPageChange: PropTypes.func.isRequired,
+  queryInfo: queryInfoPropType.isRequired
+};
+
+TopPagination.defaultProps = {
+  queryInfo: {
+    page: 1,
+    size: DEFAULT_SIZE,
+    total: 0
+  }
+};
+export default (TopPagination);

--- a/client/src/component/entries/ViewEntry.jsx
+++ b/client/src/component/entries/ViewEntry.jsx
@@ -1,0 +1,41 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { entryPropType } from '../propsValidator';
+
+export default class ViewEntry extends Component {
+  render() {
+    const { dismissModal } = this.props;
+    const { title, content, lastModified } = this.props.entry;
+
+    return (
+      <div className="scrollable">
+        <div className="modal-header">
+          <div id="modal-header-title">
+            <p data-model="lastModified">{lastModified}</p>
+            <span data-model="title" className="modal-header-title">{title}</span>
+          </div>
+          <span
+            onClick={() => {
+              dismissModal();
+            }}
+            data-dismiss="modal"
+            className="action-btn close"
+            role="button"
+            tabIndex="0"
+            aria-label="Close"
+          />
+        </div>
+        <div className="grow-body modal-body">
+          <div className="content-container">
+            {content}
+          </div>
+        </div>
+      </div>
+    );
+  }
+}
+
+ViewEntry.propTypes = {
+  dismissModal: PropTypes.func,
+  entry: entryPropType
+};

--- a/client/src/component/modal/index.jsx
+++ b/client/src/component/modal/index.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { connect } from 'react-redux';
+
+/**
+ * @return {null}
+ */
+export function Modal(props) {
+  const { content, display, loading } = props;
+  const { component: Content, props: properties, } = content;
+  if (!Content) return null;
+  return (
+    <div style={{ display }} id="modal-box" className="modal">
+      <div className="modal-content">
+        <Content loading={loading} {...properties}/>
+      </div>
+    </div>
+  );
+}
+
+Modal.propTypes = {
+  content: PropTypes.shape({
+    component: PropTypes.any,
+    props: PropTypes.object
+  }),
+  show: PropTypes.bool,
+  loading: PropTypes.bool,
+};
+
+Modal.defaultProps = {
+  content: {}
+};
+const mapStateToProps = state => ({
+  loading: state.entries.loading,
+  content: state.modal.content,
+  display: (state.modal.show) ? 'block' : 'none',
+});
+export default connect(mapStateToProps)(Modal);

--- a/client/src/component/propsValidator.js
+++ b/client/src/component/propsValidator.js
@@ -1,0 +1,13 @@
+import PropTypes from 'prop-types';
+
+export const queryInfoPropType = PropTypes.shape({
+  page: PropTypes.number,
+  size: PropTypes.number,
+  total: PropTypes.number,
+});
+export const entryPropType = PropTypes.shape({
+  id: PropTypes.number.isRequired,
+  content: PropTypes.string.isRequired,
+  title: PropTypes.string.isRequired,
+  lastModified: PropTypes.string.isRequired,
+});

--- a/client/src/index.jsx
+++ b/client/src/index.jsx
@@ -2,16 +2,29 @@ import React from 'react';
 import { render } from 'react-dom';
 import { HashRouter as Router } from 'react-router-dom';
 import { Provider } from 'react-redux';
+import { account, http } from './services/index';
+import { logoutUser, setAuthentication } from './actions/authUser';
 import store from './store/index';
 import App from './App';
 
 import './index.scss';
 
 const rootElement = document.getElementById('main');
-render(
-  <Provider store={store}>
-    <Router>
-      <App />
-    </Router>
-  </Provider>, rootElement
-);
+
+http.event.attach(() => {
+  store.dispatch(logoutUser());
+});
+
+account.identify()
+  .then(() => store.dispatch(setAuthentication(true)))
+  .catch(() => store.dispatch(setAuthentication(false)))
+  .finally(() => {
+    render(
+      <Provider store={store}>
+        <Router>
+          <App />
+        </Router>
+      </Provider>, rootElement
+    );
+  });
+module.hot.accept();

--- a/client/src/reducers/entries.js
+++ b/client/src/reducers/entries.js
@@ -1,0 +1,69 @@
+import {
+  ADD_ENTRY,
+  ENTRY_LOADING,
+  REMOVE_ENTRY,
+  SET_ENTRIES,
+  SET_QUERY,
+  UPDATE_ENTRY
+} from '../actions/entries';
+
+function entries(state = {
+  entryList: [],
+  currentEntry: {},
+  queryInfo: {}
+}, action) {
+  const { type, ...payload } = action;
+  switch (type) {
+    case SET_ENTRIES:
+      return { ...state, ...payload };
+    case UPDATE_ENTRY: {
+      const entryList = state.entryList.map((entry) => {
+        if (entry.id === payload.entry.id) {
+          return { ...entry, ...payload.entry };
+        }
+        return entry;
+      });
+      return {
+        ...state,
+        entryList
+      };
+    }
+    case REMOVE_ENTRY: {
+      const entryList = state.entryList.filter(entry => entry.id !== payload.id);
+      const queryInfo = {
+        ...state.queryInfo,
+        total: entryList.length
+      };
+      return {
+        ...state,
+        entryList,
+        queryInfo
+      };
+    }
+    case ADD_ENTRY: {
+      let { entryList } = state;
+      entryList = [payload.entry].concat(entryList);
+      const queryInfo = {
+        ...state.queryInfo,
+        total: entryList.length
+      };
+      return {
+        ...state,
+        entryList,
+        queryInfo
+      };
+    }
+    case SET_QUERY:
+      return {
+        ...state,
+        queryInfo: payload.query
+      };
+    case ENTRY_LOADING:
+      return { ...state, ...payload };
+    default:
+      return state;
+  }
+}
+
+export default entries;
+// export default loading;

--- a/client/src/reducers/index.js
+++ b/client/src/reducers/index.js
@@ -1,15 +1,19 @@
 import { combineReducers } from 'redux';
-import toolbar from './toolbar';
-import notification from './notification';
 import { authenticate, loading } from './authUserReducer';
 import redirect from './redirect';
+import toolbar from './toolbar';
+import entries from './entries';
+import modal from './modal';
+import notification from './notification';
 
 const appReducer = combineReducers({
-  toolbar,
-  notification,
   loading,
   authenticate,
-  redirect
+  toolbar,
+  redirect,
+  entries,
+  modal,
+  notification
 });
 
 export default appReducer;

--- a/client/src/reducers/modal.js
+++ b/client/src/reducers/modal.js
@@ -1,0 +1,11 @@
+import { MODAL_ACTION } from '../actions/modal';
+
+function modal(state = {}, action) {
+  const { type, ...payload } = action;
+  if (type === MODAL_ACTION) {
+    return { ...state, ...payload };
+  }
+  return state;
+}
+
+export default modal;

--- a/client/src/tests/actions/entries.test.js
+++ b/client/src/tests/actions/entries.test.js
@@ -1,0 +1,206 @@
+import faker from 'faker';
+import executeAction from '../utils/index';
+import {
+  createEntry, deleteEntry, getEntries, updateEntry
+} from '../../actions/entries';
+
+const user = {
+  username: faker.internet.userName(),
+  email: faker.internet.email(),
+  password: faker.internet.password()
+};
+
+describe('getEntries', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+  test('should execute getEntries action, simulate successful request',
+    async () => {
+      const body = {
+        data: {
+          entries: [
+            {
+              id: 0,
+              title: 'Nice Title',
+              content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla congue nulla sem, ut luctus turpis pulvinar sollicitudin. Aliquam ut hendrerit leo. Phasellus euismod vel dolor non rutrum. Morbi efficitur pellentesque odio, at ornare augue commodo ac. Quisque suscipit nisi quis urna tempus imperdiet. Cras congue, felis scelerisque luctus euismod, nibh leo sagittis odio, eget feugiat dolor libero quis tellus.',
+              createdDate: 'Jul 12, 2018',
+              lastModified: 'Jul 12, 2018',
+              userID: 1
+            }
+          ],
+          page: 1,
+          totalEntries: 10
+        },
+        status: 'Successful',
+        message: 'Successfully retrieved all user information'
+      };
+      const init = {
+        status: 200,
+        statusText: 'Success',
+      };
+
+      fetch
+        .mockResponseOnce(JSON.stringify(body), init);
+      const actions = await executeAction(getEntries, { size: 10 });
+      expect(actions)
+        .toHaveLength(2);
+    });
+  test('should execute getEntries action, simulate failed request', async () => {
+    const body = {
+      message: 'Authentication failed invalid credentials'
+    };
+    const init = {
+      status: 500,
+      statusText: 'error',
+    };
+
+    fetch
+      .mockResponseOnce(JSON.stringify(body), init);
+    const actions = await executeAction(getEntries, { size: 10 });
+    expect(actions)
+      .toHaveLength(2);
+  });
+});
+
+describe('updateEntry', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+  test('should execute updateEntry action, simulate successful request',
+    async () => {
+      const body = {
+        entry: {
+          id: 0,
+          title: 'Nice Title',
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla congue nulla sem, ut luctus turpis pulvinar sollicitudin. Aliquam ut hendrerit leo. Phasellus euismod vel dolor non rutrum. Morbi efficitur pellentesque odio, at ornare augue commodo ac. Quisque suscipit nisi quis urna tempus imperdiet. Cras congue, felis scelerisque luctus euismod, nibh leo sagittis odio, eget feugiat dolor libero quis tellus.',
+          createdDate: 'Jul 12, 2018',
+          lastModified: 'Jul 12, 2018',
+          userID: 1
+        },
+        status: 'Successful',
+        message: 'Successfully created/retrieved/updated entry'
+      };
+      const init = {
+        status: 200,
+        statusText: 'Success',
+        headers: {
+          'X-Access-Token': body.token
+        }
+      };
+
+      fetch
+        .mockResponseOnce(JSON.stringify(body), init)
+        .once(JSON.stringify({ ...user }));
+      const actions = await executeAction(updateEntry, {});
+      expect(actions)
+        .toHaveLength(4);
+    });
+  test('should execute updateEntry action, simulate failed request', async () => {
+    const body = {
+      message: '403 error'
+    };
+    const init = {
+      status: 403,
+      statusText: 'error',
+    };
+
+    fetch
+      .mockResponseOnce(JSON.stringify(body), init);
+    const actions = await executeAction(updateEntry, {});
+    expect(actions)
+      .toHaveLength(3);
+  });
+});
+
+
+describe('createEntry', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+  test('should execute createEntry action, simulate successful request',
+    async () => {
+      const body = {
+        entry: {
+          id: 0,
+          title: 'Nice Title',
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla congue nulla sem, ut luctus turpis pulvinar sollicitudin. Aliquam ut hendrerit leo. Phasellus euismod vel dolor non rutrum. Morbi efficitur pellentesque odio, at ornare augue commodo ac. Quisque suscipit nisi quis urna tempus imperdiet. Cras congue, felis scelerisque luctus euismod, nibh leo sagittis odio, eget feugiat dolor libero quis tellus.',
+          createdDate: 'Jul 12, 2018',
+          lastModified: 'Jul 12, 2018',
+          userID: 1
+        },
+        status: 'Successful',
+        message: 'Successfully created/retrieved/updated entry'
+      };
+      const init = {
+        status: 201,
+        statusText: 'Success',
+      };
+
+      fetch
+        .mockResponseOnce(JSON.stringify(body), init);
+      const actions = await executeAction(createEntry, {});
+      expect(actions)
+        .toHaveLength(4);
+    });
+  test('should execute createEntry action, simulate failed request', async () => {
+    const body = {
+      message: '400 error'
+    };
+    const init = {
+      status: 400,
+      statusText: 'error',
+    };
+
+    fetch
+      .mockResponseOnce(JSON.stringify(body), init);
+    const actions = await executeAction(createEntry, {});
+    expect(actions)
+      .toHaveLength(3);
+  });
+});
+
+describe('deleteEntry', () => {
+  beforeEach(() => {
+    fetch.resetMocks();
+  });
+  test('should execute deleteEntry action, simulate successful request',
+    async () => {
+      const body = {
+        entry: {
+          id: 0,
+          title: 'Nice Title',
+          content: 'Lorem ipsum dolor sit amet, consectetur adipiscing elit. Nulla congue nulla sem, ut luctus turpis pulvinar sollicitudin. Aliquam ut hendrerit leo. Phasellus euismod vel dolor non rutrum. Morbi efficitur pellentesque odio, at ornare augue commodo ac. Quisque suscipit nisi quis urna tempus imperdiet. Cras congue, felis scelerisque luctus euismod, nibh leo sagittis odio, eget feugiat dolor libero quis tellus.',
+          createdDate: 'Jul 12, 2018',
+          lastModified: 'Jul 12, 2018',
+          userID: 1
+        },
+        status: 'Successful',
+        message: 'Successfully created/retrieved/updated entry'
+      };
+      const init = {
+        status: 201,
+        statusText: 'Success',
+      };
+
+      fetch
+        .mockResponseOnce(JSON.stringify(body), init);
+      const actions = await executeAction(deleteEntry, 1);
+      expect(actions)
+        .toHaveLength(4);
+    });
+  test('should execute deleteEntry action, simulate failed request', async () => {
+    const body = {
+      message: '500 error'
+    };
+    const init = {
+      status: 503,
+      statusText: 'error',
+    };
+
+    fetch
+      .mockResponseOnce(JSON.stringify(body), init);
+    const actions = await executeAction(deleteEntry, 1);
+    expect(actions)
+      .toHaveLength(3);
+  });
+});

--- a/client/src/tests/actions/modal.test.js
+++ b/client/src/tests/actions/modal.test.js
@@ -1,0 +1,17 @@
+import { dismissModal, openModal } from '../../actions/modal';
+
+test('should execute getEntries action, simulate successful request',
+  async () => {
+    const store = mockStore({});
+    store.dispatch(openModal({}));
+    const actions = store.getActions();
+    expect(actions)
+      .toHaveLength(1);
+  });
+test('should execute getEntries action, simulate failed request', async () => {
+  const store = mockStore({});
+  store.dispatch(dismissModal());
+  const actions = store.getActions();
+  expect(actions)
+    .toHaveLength(1);
+});

--- a/client/src/tests/app.test.js
+++ b/client/src/tests/app.test.js
@@ -1,6 +1,7 @@
 import App from '../App';
 import Navbar from '../component/Navbar';
 import Footer from '../component/Footer';
+import Modal from '../component/modal/index';
 import Body from '../component/Body';
 import Toast from '../component/notification/Toast';
 
@@ -8,6 +9,7 @@ test('', () => {
   const wrapper = shallow(<App />);
   expect(wrapper.find(Navbar)).toHaveLength(1);
   expect(wrapper.find(Footer)).toHaveLength(1);
+  expect(wrapper.find(Modal)).toHaveLength(1);
   expect(wrapper.find(Toast)).toHaveLength(1);
   expect(wrapper.find(Body)).toHaveLength(1);
 });

--- a/client/src/tests/components/entries/index.test.js
+++ b/client/src/tests/components/entries/index.test.js
@@ -1,0 +1,380 @@
+import EmptyList from '../../../component/entries/EmptyList';
+import EntryListHeader from '../../../component/entries/EntryListHeader';
+import FloatingButton from '../../../component/entries/FloatingButton';
+import EntryListItem from '../../../component/entries/EntryListItem';
+import CreateEntry from '../../../component/entries/CreateEntry';
+import DeleteEntryDialog from '../../../component/entries/DeleteEntryDialog';
+import ViewEntry from '../../../component/entries/ViewEntry';
+import { EntryListPage } from '../../../component/entries/EntryListPage';
+
+const longTitle = 'In Simulations, Apprenticeship, Partner work and beyond Andela, you will have multiple opportunities to work with front-end frameworks such as ReactJS. You\'ll be expected to understand the key technologies and concepts that power such technologies. You\'ll also be expected to demonstrate this understanding through contributing to projects you take on.';
+const entry = {
+  id: 1,
+  content: '',
+  lastModified: '',
+  title: '',
+};
+const queryInfo = {
+  page: 2,
+  size: 2,
+  total: 10,
+};
+
+test('should render DeleteDialog', () => {
+  const props = {
+    dismissModal: jest.fn(),
+    deleteEntry: jest.fn(),
+    showToast: jest.fn(),
+    loading: false,
+  };
+  const wrapper = shallow(<DeleteEntryDialog {...props} />);
+  wrapper.find('[data-action="ok"]')
+    .simulate('click');
+  wrapper.find('[data-dismiss="cancel"]')
+    .simulate('click');
+  wrapper.find('[data-dismiss="modal"]');
+
+  expect(props.dismissModal)
+    .toBeCalled();
+  expect(props.deleteEntry)
+    .toBeCalled();
+  expect(props.dismissModal)
+    .toBeCalled();
+});
+
+test('should render ViewEntry', () => {
+  const props = {
+    dismissModal: jest.fn(),
+    entry,
+  };
+  const wrapper = shallow(<ViewEntry {...props} />);
+  wrapper.find('[data-dismiss="modal"]')
+    .simulate('click');
+
+  expect(props.dismissModal)
+    .toBeCalled();
+});
+
+test('should render EmptyList', () => {
+  shallow(<EmptyList/>);
+});
+
+test('should render EntryListHeader', () => {
+  const onPageChange = jest.fn();
+  const onCreateEntryClicked = jest.fn();
+
+  const props = {
+    onPageChange,
+    queryInfo,
+    onCreateEntryClicked,
+  };
+  const wrapper = shallow(<EntryListHeader {...props}/>);
+  wrapper.find('#addEntry')
+    .simulate('click');
+});
+
+describe('EntryListItem', () => {
+  let wrapper,
+    dropdownMock,
+    eventMock;
+  beforeEach(() => {
+    dropdownMock = jest.fn();
+    wrapper = mount(
+      <EntryListItem
+        onDropdownItemClicked={dropdownMock} entry={entry}
+      />
+    );
+    eventMock = {
+      target: {
+        matches: jest.fn(),
+        getAttribute: jest.fn(),
+        classList: {
+          contains: jest.fn(),
+          add: jest.fn(),
+          remove: jest.fn(),
+        }
+      }
+    };
+  });
+  test('should onDropdownItemClicked', () => {
+    const instance = wrapper.instance();
+    const spy = jest.spyOn(instance, 'dismissDropDownMenu');
+    instance.forceUpdate();
+    eventMock.target.getAttribute.mockReturnValueOnce('view');
+    instance.onDropdownItemClicked(eventMock);
+    expect(dropdownMock)
+      .toBeCalled();
+    expect(spy)
+      .toBeCalled();
+  });
+
+  test('should handlerWindowClicked', () => {
+    const instance = wrapper.instance();
+    const spy = jest.spyOn(instance, 'dismissDropDownMenu');
+    instance.forceUpdate();
+    eventMock.target.matches.mockReturnValueOnce(true);
+    instance.handlerWindowClicked(eventMock);
+    expect(spy)
+      .not
+      .toBeCalled();
+
+    eventMock.target.matches.mockReturnValueOnce(false);
+    instance.handlerWindowClicked(eventMock);
+    expect(spy)
+      .toBeCalled();
+  });
+
+  test('should handle show drop down menu', () => {
+    const event = {
+      target: {
+        ...eventMock.target,
+        nextElementSibling: { ...eventMock.target }
+      }
+    };
+    event.target.getAttribute.mockReturnValueOnce(true);
+    wrapper.find('[data-action="dropdown-toggle"]')
+      .simulate('click', event);
+
+    expect(event.target.nextElementSibling.classList.add)
+      .toBeCalledWith('open');
+  });
+
+  test('should handle hide drop down menu', () => {
+    const event = {
+      target: {
+        ...eventMock.target,
+        nextElementSibling: { ...eventMock.target }
+      }
+    };
+    event.target.nextElementSibling.classList.contains.mockReturnValueOnce(true);
+    wrapper.find('[data-action="dropdown-toggle"]')
+      .simulate('click', event);
+
+    expect(event.target.nextElementSibling.classList.remove)
+      .toBeCalledWith('open');
+  });
+
+  test('should handleViewClicked', () => {
+    wrapper.find('.entry')
+      .simulate('click', eventMock);
+    expect(dropdownMock)
+      .toBeCalled();
+  });
+  test('should not handleViewClicked when it contains data-action attribute ', () => {
+    eventMock.target.getAttribute.mockReturnValueOnce(true);
+    wrapper.find('.entry')
+      .simulate('click', eventMock);
+    expect(dropdownMock)
+      .not
+      .toBeCalled();
+  });
+  test('should not handleViewClicked when it contains dropdown-toggle class', () => {
+    eventMock.target.classList.contains.mockReturnValueOnce(true);
+    wrapper.find('.entry')
+      .simulate('click', eventMock);
+    expect(dropdownMock)
+      .not
+      .toBeCalled();
+  });
+});
+
+
+describe('FloatingButton', () => {
+  let wrapper;
+  beforeAll(() => {
+    jest.useFakeTimers();
+    wrapper = mount(<FloatingButton/>);
+  });
+  afterAll(() => {
+    wrapper.unmount();
+  });
+
+  test('should render FloatingButton', () => {
+    const instance = wrapper.instance();
+    instance.forceUpdate();
+    instance.handleScrollEvent();
+    jest.runAllTimers();
+    instance.handleScrollEvent();
+  });
+});
+
+describe('CreateEntry', () => {
+  test('should render CreateEntry create mode', () => {
+    const props = {
+      dismissModal: jest.fn(),
+      mode: 'create',
+      saveEntry: jest.fn(),
+      entry,
+      showToast: jest.fn(),
+      loading: false
+    };
+    shallow(<CreateEntry {...props}/>);
+  });
+  let props,
+    wrapper;
+  beforeEach(() => {
+    props = {
+      dismissModal: jest.fn(),
+      mode: 'edit',
+      saveEntry: jest.fn(),
+      entry,
+      showToast: jest.fn(),
+      loading: true
+    };
+    wrapper = shallow(<CreateEntry {...props}/>);
+  });
+  test('should close modal', () => {
+    wrapper.find('.action-btn.close')
+      .simulate('click', {
+        target: {}
+      });
+    expect(props.dismissModal)
+      .toBeCalled();
+  });
+
+  test('should create entry when provided with a valid input', () => {
+    wrapper.find('.action-btn.close')
+      .simulate('click', {
+        target: {}
+      });
+
+    wrapper.find('[name=\'content\']')
+      .simulate('change', {
+        target: {
+          name: 'content',
+          value: 'Valid content'
+        }
+      });
+    wrapper.find('.form-input.modal-header-input')
+      .at(0)
+      .simulate('change', {
+        target: {
+          name: 'title',
+          value: 'Valid input'
+        }
+      });
+
+    const instance = wrapper.instance();
+    instance.forceUpdate();
+    expect(instance.state.title)
+      .toEqual('Valid input');
+    expect(instance.state.content)
+      .toEqual('Valid content');
+
+    wrapper.find('[data-action="save"]')
+      .simulate('click', {});
+    expect(props.saveEntry)
+      .toBeCalled();
+  });
+
+  test('should show toast when provided with invalid input', () => {
+    wrapper.find('.form-input.modal-header-input')
+      .at(0)
+      .simulate('change', {
+        target: {
+          name: 'title',
+          value: 'val'
+        }
+      });
+
+    wrapper.find('[data-action="save"]')
+      .simulate('click', {});
+
+    wrapper.find('.form-input.modal-header-input')
+      .at(0)
+      .simulate('change', {
+        target: {
+          name: 'title',
+          value: 'val$$%^&*@(@&*(#)(*&^&*@()'
+        }
+      });
+
+    wrapper.find('[data-action="save"]')
+      .simulate('click', {});
+
+    wrapper.find('.form-input.modal-header-input')
+      .at(0)
+      .simulate('change', {
+        target: {
+          name: 'title',
+          value: longTitle
+        }
+      });
+
+    wrapper.find('[data-action="save"]')
+      .simulate('click', {});
+
+
+    wrapper.find('[name=\'content\']')
+      .simulate('change', {
+        target: {
+          name: 'content',
+          value: 'Va'
+        }
+      });
+
+    wrapper.find('[data-action="save"]')
+      .simulate('click', {});
+
+
+    expect(props.showToast)
+      .toBeCalled();
+
+    expect(props.showToast.mock.calls)
+      .toHaveLength(4);
+  });
+});
+
+describe('EntryListPage', () => {
+  test('', () => {
+    const props = {
+      getEntries: jest.fn(),
+      updateEntry: jest.fn(),
+      openModal: jest.fn(),
+      dismissModal: jest.fn(),
+      deleteEntry: jest.fn(),
+      showToast: jest.fn(),
+      createEntry: jest.fn(),
+      entryList: [entry],
+      authenticated: true,
+      queryInfo,
+    };
+    const wrapper = shallow(<EntryListPage {...props}/>);
+    const instance = wrapper.instance();
+    expect(instance.openModal(''))
+      .toEqual(null);
+    instance.openCreateEntryModal();
+    const defaultProps = {
+      dismissModal: props.dismissModal,
+      showToast: props.showToast,
+      mode: 'create',
+      saveEntry: props.createEntry,
+    };
+    const content = {
+      component: CreateEntry,
+      props: defaultProps,
+    };
+    expect(props.openModal)
+      .toBeCalledWith(content);
+
+    instance.openModal('edit', entry);
+
+    // content = {
+    //   component: CreateEntry,
+    //   props: {
+    //     ...defaultProps,
+    //     ...{
+    //       mode: 'edit',
+    //       saveEntry: (data) => {
+    //         props.updateEntry(data);
+    //       },
+    //       entry
+    //     }
+    //   },
+    // };
+    instance.openModal('view', entry);
+    instance.openModal('delete', entry);
+    expect(props.openModal)
+      .toBeCalled();
+  });
+});

--- a/client/src/tests/components/entries/pagination.test.js
+++ b/client/src/tests/components/entries/pagination.test.js
@@ -1,0 +1,67 @@
+import BottomPagination from '../../../component/entries/BottomPagination';
+import { TopPagination } from '../../../component/entries/TopPagination';
+
+const queryInfo = {
+  page: 2,
+  size: 2,
+  total: 10,
+};
+describe('', () => {
+  test('', () => {
+    const onPageChangeMock = jest.fn();
+    const getAttribute = jest.fn();
+    getAttribute.mockReturnValueOnce('next');
+    getAttribute.mockReturnValueOnce('prev');
+    const wrapper = shallow(<TopPagination
+      onPageChange={onPageChangeMock}
+      queryInfo={queryInfo}/>);
+    const mock = {
+      target: {
+        getAttribute
+      }
+    };
+    wrapper.find('.next-js').simulate('click', mock);
+    expect(onPageChangeMock).toBeCalled();
+    expect(getAttribute)
+      .toBeCalled();
+
+    wrapper.find('.prev-js').simulate('click', mock);
+    expect(onPageChangeMock).toBeCalled();
+    expect(getAttribute)
+      .toBeCalled();
+    expect(getAttribute.mock.calls.length)
+      .toBe(2);
+    expect(onPageChangeMock.mock.calls.length)
+      .toBe(2);
+  });
+});
+
+describe('BottomPagination', () => {
+  test('', () => {
+    const onPageChangeMock = jest.fn();
+    const getAttribute = jest.fn();
+    getAttribute.mockReturnValueOnce('next');
+    getAttribute.mockReturnValueOnce('prev');
+    const wrapper = shallow(<BottomPagination
+      onPageChange={onPageChangeMock}
+      queryInfo={queryInfo}/>);
+    const mock = {
+      target: {
+        getAttribute
+      }
+    };
+    wrapper.find('.next-js').simulate('click', mock);
+    expect(onPageChangeMock).toBeCalled();
+    expect(getAttribute)
+      .toBeCalled();
+
+    wrapper.find('.prev-js').simulate('click', mock);
+    expect(onPageChangeMock).toBeCalled();
+    expect(getAttribute)
+      .toBeCalled();
+    expect(getAttribute.mock.calls.length)
+      .toBe(2);
+    expect(onPageChangeMock.mock.calls.length)
+      .toBe(2);
+  });
+});

--- a/client/src/tests/components/modal.test.js
+++ b/client/src/tests/components/modal.test.js
@@ -1,0 +1,19 @@
+import ModalWithStore, { Modal } from '../../component/modal/index';
+
+const dummyComponent = () => (<div>This is a dummy component</div>);
+
+test('should render Footer', () => {
+  const content = {
+    component: dummyComponent,
+    props: {}
+  };
+  shallow(<Modal show={true} content={content} loading={false}/>);
+});
+
+test('should render Footer with store', () => {
+  const store = mockStore({
+    entries: {},
+    modal: {}
+  });
+  shallow(<ModalWithStore store={store}/>);
+});

--- a/client/src/tests/components/notification/alert.test.js
+++ b/client/src/tests/components/notification/alert.test.js
@@ -1,0 +1,13 @@
+import { Alert } from '../../../component/notification/Alert';
+
+test('should render ButtonLoader', () => {
+  const dismissAlert = jest.fn();
+  const wrapper = shallow(<Alert show={true} type={'error'} text={''}
+                                 dismissAlert={dismissAlert}/>);
+
+  wrapper.find('.close-btn')
+    .simulate('click');
+  expect(dismissAlert)
+    .toBeCalled();
+  wrapper.unmount();
+});

--- a/client/src/tests/components/notification/toast.test.js
+++ b/client/src/tests/components/notification/toast.test.js
@@ -1,0 +1,16 @@
+import { Toast } from '../../../component/notification/Toast';
+
+test('should render Toast ', () => {
+  const dismissAlert = jest.fn();
+  const wrapper = shallow(<Toast show={true} text={''} type={'error'} title={''}
+                                 dismissToast={dismissAlert}/>);
+
+  wrapper.find('.title > .close-btn')
+    .simulate('click');
+  expect(dismissAlert)
+    .toBeCalled();
+});
+
+test('should render Toast', () => {
+  shallow(<Toast show={false}/>);
+});

--- a/client/src/tests/components/signin.page.test.js
+++ b/client/src/tests/components/signin.page.test.js
@@ -1,0 +1,79 @@
+import faker from 'faker';
+import { SigninPage } from '../../component/SigninPage';
+
+test('should render SignupPage', () => {
+  const fixFooter = jest.fn();
+  const hideNavBar = jest.fn();
+  const showAlert = jest.fn();
+  const login = jest.fn();
+  const createUser = jest.fn();
+  const authenticated = true;
+  const signingIn = false;
+  const redirectToReferrer = { to: 'url' };
+  const props = {
+    authenticated,
+    signingIn,
+    fixFooter,
+    hideNavBar,
+    showAlert,
+    createUser,
+    login,
+    redirectToReferrer
+  };
+  shallow(<SigninPage {...props}/>);
+});
+
+test('should render SigninPage', () => {
+  const fixFooter = jest.fn();
+  const hideNavBar = jest.fn();
+  const showAlert = jest.fn();
+  const login = jest.fn();
+  const authenticated = false;
+  const signingIn = false;
+  const props = {
+    authenticated,
+    signingIn,
+    fixFooter,
+    hideNavBar,
+    showAlert,
+    login
+  };
+  const wrapper = shallow(
+    <SigninPage {...props}/>
+  );
+  const btn = wrapper.find('[type="button"]');
+  btn.simulate('click');
+  expect(login)
+    .not
+    .toBeCalled();
+  expect(showAlert)
+    .toBeCalled();
+
+  const instance = wrapper.instance();
+  const password = faker.internet.password();
+  const email = faker.internet.email();
+  instance.setState({
+    password,
+  });
+  btn.simulate('click');
+
+  const eventChangeEvent = {
+    target: {
+      name: 'email',
+      value: email,
+    }
+  };
+  wrapper.find('#email')
+    .simulate('change', eventChangeEvent);
+  btn.simulate('click');
+
+  expect(login)
+    .toBeCalled();
+  expect(login)
+    .toBeCalledWith({
+      email,
+      password
+    });
+
+  wrapper.unmount();
+});

--- a/client/src/tests/modal.test.js
+++ b/client/src/tests/modal.test.js
@@ -1,0 +1,18 @@
+import ModalWithStore, { Modal } from '../component/modal';
+
+const dummyComponent = () => (<div>This is a dummy component</div>);
+
+test('should render Footer', () => {
+  const content = {
+    component: dummyComponent,
+    props: {}
+  };
+  shallow(<Modal show={true} content={content} loading={false}/>);
+});
+test('should render Footer with store', () => {
+  const store = mockStore({
+    entries: {},
+    modal: {}
+  });
+  shallow(<ModalWithStore store={store}/>);
+});

--- a/client/src/tests/private.route.test.js
+++ b/client/src/tests/private.route.test.js
@@ -1,0 +1,25 @@
+import MockRouter from 'react-mock-router';
+import { Redirect } from 'react-router-dom';
+import PrivateRoute from '../PrivateRoute';
+import store from '../store/index';
+
+test('should render component', () => {
+  mount(
+    <MockRouter>
+      <PrivateRoute
+        component={() => (<div/>)}
+        store={store}/>
+    </MockRouter>
+  );
+});
+test('should render redirect', () => {
+  const wrapper = mount(
+    <MockRouter>
+      <PrivateRoute
+        component={() => (<div/>)}
+        location={{ pathname: '' }}
+        store={store}/>
+    </MockRouter>
+  );
+  expect(wrapper.find(Redirect)).toHaveLength(1);
+});

--- a/client/src/tests/reducers/entries.test.js
+++ b/client/src/tests/reducers/entries.test.js
@@ -1,0 +1,169 @@
+import {
+  ADD_ENTRY,
+  ENTRY_LOADING,
+  REMOVE_ENTRY,
+  SET_ENTRIES,
+  SET_QUERY,
+  UPDATE_ENTRY
+} from '../../actions/entries';
+import entries from '../../reducers/entries';
+
+test('SET_ENTRIES', () => {
+  const state = {
+    entryList: [],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    type: SET_ENTRIES,
+    entryList: [{
+      id: 1,
+      title: 'title',
+      content: 'content'
+    }],
+  };
+  const newState = entries(state, action);
+  expect(newState.entryList)
+    .toEqual(action.entryList);
+});
+
+test('UPDATE_ENTRY', () => {
+  const state = {
+    entryList: [{
+      id: 1,
+      title: 'title',
+      content: 'content'
+    }, {
+      id: 2,
+      title: 'title',
+      content: 'content'
+    }],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    type: UPDATE_ENTRY,
+    entry: {
+      id: 1,
+      title: 'mod title',
+      content: 'content'
+    },
+  };
+  const newState = entries(state, action);
+  expect(newState.entryList)
+    .toEqual([{
+      id: 1,
+      title: 'mod title',
+      content: 'content'
+    }, {
+      id: 2,
+      title: 'title',
+      content: 'content'
+    }]);
+});
+
+test('REMOVE_ENTRY', () => {
+  const state = {
+    entryList: [{
+      id: 1,
+      title: 'title',
+      content: 'content'
+    }, {
+      id: 2,
+      title: 'title',
+      content: 'content'
+    }],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    type: REMOVE_ENTRY,
+    id: 1,
+  };
+  const newState = entries(state, action);
+  expect(newState.entryList)
+    .toEqual([{
+      id: 2,
+      title: 'title',
+      content: 'content'
+    }]);
+});
+
+test('ADD_ENTRY', () => {
+  const state = {
+    entryList: [],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    type: ADD_ENTRY,
+    entry: {
+      id: 1,
+      title: 'title',
+      content: 'content'
+    },
+  };
+  const newState = entries(state, action);
+  expect(newState.entryList)
+    .toEqual([{
+      id: 1,
+      title: 'title',
+      content: 'content'
+    }]);
+});
+
+test('SET_QUERY', () => {
+  const state = {
+    entryList: [],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    type: SET_QUERY,
+    query: {
+      total: 10,
+      size: 2,
+      page: 2
+    },
+  };
+  const newState = entries(state, action);
+  expect(newState.queryInfo)
+    .toEqual({
+      total: 10,
+      size: 2,
+      page: 2
+    });
+});
+test('ENTRY_LOADING', () => {
+  const state = {
+    entryList: [],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    type: ENTRY_LOADING,
+    loading: false,
+  };
+  const newState = entries(state, action);
+  expect(newState)
+    .toEqual({
+      ...state,
+      loading: false,
+    });
+});
+
+test('NO_ACTION', () => {
+  const state = {
+    entryList: [],
+    currentEntry: {},
+    queryInfo: {}
+  };
+  const action = {
+    test: 'test'
+  };
+  const newState = entries(state, action);
+  expect(newState)
+    .toEqual({
+      ...state,
+    });
+});

--- a/client/src/tests/reducers/modal.test.js
+++ b/client/src/tests/reducers/modal.test.js
@@ -1,0 +1,32 @@
+import modal from '../../reducers/modal';
+import { MODAL_ACTION } from '../../actions/modal';
+
+test('MODAL_ACTION', () => {
+  const state = {
+    modal: {}
+  };
+  const action = {
+    type: MODAL_ACTION,
+    test: 'test'
+  };
+  const newState = modal(state, action);
+  expect(newState)
+    .toEqual({
+      ...state,
+      test: 'test'
+    });
+});
+
+test('NO_ACTION', () => {
+  const state = {
+    modal: {}
+  };
+  const action = {
+    test: 'test'
+  };
+  const newState = modal(state, action);
+  expect(newState)
+    .toEqual({
+      ...state,
+    });
+});


### PR DESCRIPTION
#### What does this PR do?
- Implement CRUD functionality
- Add tests to all components
- Update Travis configuration to fix deployment to gh-page

#### Description of Task to be completed?
- N/A

#### How should this be manually tested?- clone repo and run `npm install`
- rename .env.sample file to .env, then add to the .env file
```
DB_URL=postgres://username:password@host:port/<database>
TEST_DB_URL=postgres://username:password@host:port/<test database>
```
- run `npm start` to start Api server and `npm test` to run the test, run `npm run webpack:build`, to build UI templates
- To run frontend test alone use `npm run test:ui` and `npm run test:server` to run the test for the backend.
- navigate to localhost:3000/signin or you can click the sign in button on the navbar
- Upon logging in you will be redirected to the dashboard, click on the create entry button to create a new diary entry
#### Any background context you want to provide?
N/A
#### What are the relevant pivotal tracker stories?
[`#162149741 `](https://www.pivotaltracker.com/n/projects/2183365/stories/162149741)